### PR TITLE
Add folder_name to config/final.yml for S3 blob namespacing

### DIFF
--- a/config/final.yml
+++ b/config/final.yml
@@ -4,3 +4,4 @@ blobstore:
   provider: s3
   options:
     bucket_name: buildpacks.cloudfoundry.org
+    folder_name: dotnet-core-buildpack


### PR DESCRIPTION
## Summary

Adds `folder_name` to the blobstore options in `config/final.yml` so that BOSH blobs are stored under a per-buildpack namespaced prefix in the S3 bucket (`s3://buildpacks.cloudfoundry.org/<buildpack-name>/`) rather than at the bucket root.

All existing blobs have already been copied to their namespaced locations in S3. The root copies are retained for a 30-day rollback grace period.

## RFC

cloudfoundry/community#1403