### PR TITLE
Add cflinuxfs5 support for .NET Core buildpack

### DIFF
--- a/jobs/dotnet-core-buildpack/spec
+++ b/jobs/dotnet-core-buildpack/spec
@@ -3,6 +3,7 @@ name: dotnet-core-buildpack
 templates: {}
 
 packages:
+- dotnet-core-buildpack-cflinuxfs5
 - dotnet-core-buildpack-cflinuxfs4
 
 properties: {}

--- a/packages/dotnet-core-buildpack-cflinuxfs5/packaging
+++ b/packages/dotnet-core-buildpack-cflinuxfs5/packaging
@@ -1,0 +1,2 @@
+    set -e -x
+    cp dotnet-core-buildpack/dotnet-core?buildpack-*.zip ${BOSH_INSTALL_TARGET}

--- a/packages/dotnet-core-buildpack-cflinuxfs5/spec
+++ b/packages/dotnet-core-buildpack-cflinuxfs5/spec
@@ -1,0 +1,4 @@
+---
+name: dotnet-core-buildpack-cflinuxfs5
+files:
+- dotnet-core-buildpack/dotnet-core?buildpack-cflinuxfs5-*.zip


### PR DESCRIPTION
## Pull Request: Add cflinuxfs5 support for .NET Core buildpack

Adds cflinuxfs5 (Ubuntu 24.04 noble) stack support to the dotnet-core-buildpack BOSH release, following the same pattern used for cflinuxfs4.

### Changes:
- Create packages/dotnet-core-buildpack-cflinuxfs5/spec - package specification
- Create packages/dotnet-core-buildpack-cflinuxfs5/packaging - build script
- Update jobs/dotnet-core-buildpack/spec to reference cflinuxfs5 package

Both cflinuxfs4 and cflinuxfs5 packages will be included in future releases, enabling operators to deploy .NET Core applications on either stack during the migration period from jammy (cflinuxfs4) to noble (cflinuxfs5).

The next BOSH release will include the cflinuxfs5 package, making it available for Cloud Foundry deployments.